### PR TITLE
Target es2019 to remove optional chaining

### DIFF
--- a/packages/fetch/tsconfig.json
+++ b/packages/fetch/tsconfig.json
@@ -1,13 +1,13 @@
 {
-    "compilerOptions": {
-        "target": "es2020",
-        "strict": true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "noUncheckedIndexedAccess": true,
-        "declaration": true,
-        "declarationDir": "./dist",
-        "skipLibCheck": true,
-        "outDir": "dist"
-    }
+	"compilerOptions": {
+		"target": "es2019",
+		"strict": true,
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"noUncheckedIndexedAccess": true,
+		"declaration": true,
+		"declarationDir": "./dist",
+		"skipLibCheck": true,
+		"outDir": "dist"
+	}
 }


### PR DESCRIPTION
Native optional chaining is bit too fresh for current build tools.

This compiles 

```ts
const duration = responses.groups[index]?.duration ?? 0;
```

down to ternaries

```ts
const duration = (_b = (_a = responses.groups[index]) === null || _a === void 0 ? void 0 : _a.duration) !== null && _b !== void 0
```