### PR TITLE
Remove keyboard arrow navigation

### DIFF
--- a/packages/ui/classnames.d.ts
+++ b/packages/ui/classnames.d.ts
@@ -13,8 +13,6 @@ type ClassNames =
   | "findkit--header"
   | "findkit--header-hidden"
   | "findkit--hit"
-  | "findkit--hit-not-selected"
-  | "findkit--hit-selected"
   | "findkit--load-more-button"
   | "findkit--logo"
   | "findkit--logo-animating"

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -110,59 +110,8 @@ function GroupTitle(props: { title: string; total: number }) {
 	);
 }
 
-function getScrollContainer(node: HTMLElement | null): HTMLElement | null {
-	if (!node) {
-		return null;
-	}
-
-	if (node.scrollHeight > node.clientHeight) {
-		if (node === document.body) {
-			return document.documentElement;
-		}
-		return node;
-	}
-
-	return getScrollContainer(node.parentElement);
-}
-
-function scrollIntoViewIfNeeded(el: HTMLElement, offsetSelector?: string) {
-	const scrollContainer = getScrollContainer(el);
-	let headerOffset = 0;
-	const margin = 30;
-
-	if (!scrollContainer) {
-		return;
-	}
-
-	if (offsetSelector) {
-		const header = scrollContainer.querySelector(offsetSelector);
-		if (header instanceof HTMLElement) {
-			headerOffset = header.clientHeight;
-		}
-	}
-
-	const rect = el.getBoundingClientRect();
-
-	if (rect.top < headerOffset) {
-		scrollContainer.scrollTo({
-			top: scrollContainer.scrollTop + rect.top - headerOffset - margin,
-			behavior: "smooth",
-		});
-	} else if (rect.bottom > scrollContainer.clientHeight) {
-		scrollContainer.scrollTo({
-			top:
-				scrollContainer.scrollTop +
-				rect.bottom -
-				scrollContainer.clientHeight +
-				margin,
-			behavior: "smooth",
-		});
-	}
-}
-
-function Hit(props: { hit: SearchResultHit; selected: boolean }) {
+function Hit(props: { hit: SearchResultHit }) {
 	const engine = useSearchEngine();
-	const state = useSearchEngineState();
 
 	const handleLinkClick: MouseEventHandler<HTMLDivElement> = (e) => {
 		if (!(e.target instanceof HTMLAnchorElement)) {
@@ -183,28 +132,8 @@ function Hit(props: { hit: SearchResultHit; selected: boolean }) {
 		});
 	};
 
-	const ref = useRef<HTMLElement>(null);
-	useEffect(() => {
-		if (props.selected && ref.current) {
-			const el = ref.current;
-			scrollIntoViewIfNeeded(el, ".findkit--header");
-
-			// XXX Goes under the header...
-			// ref.current?.scrollIntoView({ behavior: "smooth" });
-		}
-	}, [props.selected, ref]);
-
 	return (
-		<View
-			key={props.hit.url}
-			ref={ref}
-			cn={{
-				hit: true,
-				"hit-selected": props.selected,
-				"hit-not-selected": state.selectedHit && !props.selected,
-			}}
-			onClick={handleLinkClick}
-		>
+		<View key={props.hit.url} cn="hit" onClick={handleLinkClick}>
 			<Slot
 				name="Hit"
 				key={props.hit.url}
@@ -224,18 +153,10 @@ function HitList(props: {
 	groupIndex: number;
 	hits: ReadonlyArray<SearchResultHit>;
 }) {
-	const selectedHit = useSearchEngineState().selectedHit;
-
 	return (
 		<>
-			{props.hits.map((hit, hitIndex) => {
-				const selected = Boolean(
-					selectedHit &&
-						props.groupIndex === selectedHit.groupIndex &&
-						selectedHit.hitIndex === hitIndex,
-				);
-
-				return <Hit hit={hit} selected={selected} />;
+			{props.hits.map((hit) => {
+				return <Hit hit={hit} />;
 			})}
 		</>
 	);

--- a/packages/ui/src/modal.tsx
+++ b/packages/ui/src/modal.tsx
@@ -230,10 +230,7 @@ function Modal() {
 	const duration = 150;
 	const delayed = useDelay(show, duration);
 	const unmount = !delayed && !show;
-	const isScrollingDown = useIsScrollingDown(
-		containerRef,
-		show && !state.selectedHit,
-	);
+	const isScrollingDown = useIsScrollingDown(containerRef, show);
 
 	useScrollLock(!unmount);
 
@@ -247,7 +244,7 @@ function Modal() {
 		<View
 			cn={{
 				header: true,
-				"header-hidden": isScrollingDown && !state.selectedHit,
+				"header-hidden": isScrollingDown,
 			}}
 		>
 			<Slot name="Header" props={{}}>

--- a/packages/ui/styles/findkit.scoped.css
+++ b/packages/ui/styles/findkit.scoped.css
@@ -133,24 +133,6 @@
 	transition: opacity 200ms ease;
 }
 
-.hit-not-selected {
-	opacity: 0.5;
-}
-
-.hit-selected {
-	border: 5px dashed salmon;
-	background-color: blanchedalmond;
-}
-
-.hit-selected::before {
-	content: "️•";
-	position: absolute;
-	top: var(--space-1-5);
-	left: calc(-1 * var(--space-1));
-	font-size: var(--space-6);
-	box-sizing: border-box;
-}
-
 .group {
 }
 


### PR DESCRIPTION
Too much code for too little and this still had edge cases. Native focus navigation with tab key will still work. Will revisit if there are demand and good arguments for it.

Old demo of this https://cdn.findkit.com/ui/v0.0.1-dev.aa7b2b23b0/demo.html?fdk_q=wordpress