### PR TITLE
Use custom PRIVATE_ prefix for mangling

### DIFF
--- a/packages/ui/jakefile.js
+++ b/packages/ui/jakefile.js
@@ -30,6 +30,7 @@ async function runEsbuild(options = {}) {
 			bundle: true,
 			minify: options.minify,
 			target: "es2022",
+			mangleProps: /^PRIVATE_/,
 			format,
 			tsconfig: "tsconfig.esbuild.json",
 			sourcemap: true,

--- a/packages/ui/src/emitter.ts
+++ b/packages/ui/src/emitter.ts
@@ -19,19 +19,19 @@ export interface EventObject {
  * Simple event emitter
  */
 export class Emitter<Events extends {}, Source> {
-	#handlers = new Map<keyof Events, Set<Handler>>();
-	#source: Source;
+	PRIVATE_handlers = new Map<keyof Events, Set<Handler>>();
+	PRIVATE_source: Source;
 
 	constructor(source: Source) {
-		this.#source = source;
+		this.PRIVATE_source = source;
 	}
 
 	on<EventName extends keyof Events>(
 		eventName: EventName,
 		handler: (event: Events[EventName] & { source: Source }) => void,
 	) {
-		const set = this.#handlers.get(eventName) || new Set();
-		this.#handlers.set(eventName, set);
+		const set = this.PRIVATE_handlers.get(eventName) || new Set();
+		this.PRIVATE_handlers.set(eventName, set);
 		set.add(handler);
 		return () => {
 			this.off(eventName, handler);
@@ -53,20 +53,20 @@ export class Emitter<Events extends {}, Source> {
 		eventName: EventName,
 		handler: (event: any) => void,
 	) {
-		const set = this.#handlers.get(eventName);
+		const set = this.PRIVATE_handlers.get(eventName);
 		set?.delete(handler);
 	}
 
 	dispose() {
-		this.#handlers.clear();
+		this.PRIVATE_handlers.clear();
 	}
 
 	emit<EventName extends keyof Events>(
 		eventName: EventName,
 		event: Events[EventName],
 	) {
-		const payload = { ...event, ui: this.#source };
-		const set = this.#handlers.get(eventName);
+		const payload = { ...event, ui: this.PRIVATE_source };
+		const set = this.PRIVATE_handlers.get(eventName);
 
 		if (typeof document !== "undefined") {
 			const event = new Event("findkit-ui-event");

--- a/packages/ui/src/resources.ts
+++ b/packages/ui/src/resources.ts
@@ -3,20 +3,20 @@
  * `.dispose()`.
  */
 export class Resources {
-	#cleaners = new Set<() => void>();
-	#disposed = false;
-	#onDispose?: () => void;
+	PRIVATE_cleaners = new Set<() => void>();
+	PRIVATE_disposed = false;
+	PRIVATE_onDispose?: () => void;
 
 	constructor(onDispose?: () => void) {
-		this.#onDispose = onDispose;
+		this.PRIVATE_onDispose = onDispose;
 	}
 
 	get disposed() {
-		return this.#disposed;
+		return this.PRIVATE_disposed;
 	}
 
 	get size() {
-		return this.#cleaners.size;
+		return this.PRIVATE_cleaners.size;
 	}
 
 	/**
@@ -26,18 +26,18 @@ export class Resources {
 	create = (createResource: () => () => void) => {
 		// Resource was disposed before it was actually created. Just return a
 		// dummy cleaner.
-		if (this.#disposed) {
+		if (this.PRIVATE_disposed) {
 			return () => {};
 		}
 
 		const cleanup = createResource();
 
-		this.#cleaners.add(cleanup);
+		this.PRIVATE_cleaners.add(cleanup);
 
 		return () => {
 			// Ensure cleaner is executed only once
-			if (this.#cleaners.has(cleanup)) {
-				this.#cleaners.delete(cleanup);
+			if (this.PRIVATE_cleaners.has(cleanup)) {
+				this.PRIVATE_cleaners.delete(cleanup);
 				cleanup();
 			}
 		};
@@ -45,7 +45,7 @@ export class Resources {
 
 	child = (onDispose?: () => void) => {
 		const child = new Resources(() => {
-			this.#cleaners.delete(child.dispose);
+			this.PRIVATE_cleaners.delete(child.dispose);
 			onDispose?.();
 		});
 
@@ -62,13 +62,13 @@ export class Resources {
 	 * Dispose all resources
 	 */
 	dispose = () => {
-		this.#disposed = true;
-		const copy = Array.from(this.#cleaners);
+		this.PRIVATE_disposed = true;
+		const copy = Array.from(this.PRIVATE_cleaners);
 		// Remove the cleaners before calling them to avoid duplicate calls when
 		// cleaners are manually called from other cleaners
-		this.#cleaners.clear();
+		this.PRIVATE_cleaners.clear();
 		copy.forEach((fn) => fn());
-		this.#onDispose?.();
+		this.PRIVATE_onDispose?.();
 	};
 }
 


### PR DESCRIPTION
True privates are not well enough supported by tools. For example they break Vite.


Transformed with sed and some manual fixing:

```
sed -i '' -E 's/\#([a-zA-Z]+)/PRIVATE_\1/g' ./src/search-engine.tsx
sed -i '' -E 's/this\.#/this.PRIVATE_/g' ./src/search-engine.tsx
```