### PR TITLE
Target ES2021

### DIFF
--- a/packages/ui/jakefile.js
+++ b/packages/ui/jakefile.js
@@ -29,7 +29,7 @@ async function runEsbuild(options = {}) {
 		.build({
 			bundle: true,
 			minify: options.minify,
-			target: "es2022",
+			target: "es2021",
 			mangleProps: /^PRIVATE_/,
 			format,
 			tsconfig: "tsconfig.esbuild.json",


### PR DESCRIPTION
Actually privates were ok for vite. Property initializers were the issue. Compile down to ES2021 to remove them.